### PR TITLE
Load Polym Table recipes from config folder

### DIFF
--- a/src/main/java/com/junnio/polym/Polym.java
+++ b/src/main/java/com/junnio/polym/Polym.java
@@ -1,10 +1,11 @@
 package com.junnio.polym;
 
 import com.junnio.polym.block.ModBlocks;
-import com.junnio.polym.command.ModCommand;
+import com.junnio.polym.config.RecipeConfigLoader;
 import com.junnio.polym.item.ModItemGroups;
 import com.junnio.polym.item.ModItems;
 import com.junnio.polym.recipe.ModRecipes;
+import com.junnio.polym.recipe.PolymRecipeRegistry;
 import com.junnio.polym.screen.ModScreenHandlers;
 import com.junnio.polym.sound.ModSounds;
 import net.fabricmc.api.ModInitializer;
@@ -24,7 +25,10 @@ public class Polym implements ModInitializer {
 		ModRecipes.initialize();
 		ModScreenHandlers.initialize();
 		ModSounds.initialize();
-		ModCommand.register();
-		LoggerFactory.getLogger(MOD_ID).info("Polym Initialized!");
+
+		// Polym Table-only recipes (config-driven)
+		RecipeConfigLoader.createExampleRecipeIfMissing();
+		RecipeConfigLoader.loadAllRecipes();
+		LOGGER.info("Polym Table config recipes loaded: {}", PolymRecipeRegistry.size());
 	}
 }

--- a/src/main/java/com/junnio/polym/config/RecipeConfigLoader.java
+++ b/src/main/java/com/junnio/polym/config/RecipeConfigLoader.java
@@ -41,13 +41,13 @@ public final class RecipeConfigLoader {
             Path example = CONFIG_DIR.resolve("example_copper_coin.json");
             if (Files.exists(example)) return;
 
+            // NOTE: This uses a 1x1 pattern so it can match anywhere in the 3x3 grid,
+            // and it does NOT require all other slots to be empty.
             JsonObject root = new JsonObject();
             root.addProperty("id", "example_copper_coin");
 
             JsonArray pattern = new JsonArray();
-            pattern.add("   ");
-            pattern.add(" C ");
-            pattern.add("   ");
+            pattern.add("C");
             root.add("pattern", pattern);
 
             JsonObject key = new JsonObject();
@@ -55,7 +55,7 @@ public final class RecipeConfigLoader {
             root.add("key", key);
 
             JsonObject result = new JsonObject();
-            result.addProperty("item", Polym.MOD_ID + ":copper_coin");
+            result.addProperty("item", "minecraft:amethyst_shard");
             result.addProperty("count", 1);
             root.add("result", result);
 
@@ -97,7 +97,7 @@ public final class RecipeConfigLoader {
         JsonObject root = JsonParser.parseString(Files.readString(path)).getAsJsonObject();
 
         String id = requireString(root, "id");
-        String[] pattern = parsePattern(root);
+        String[] pattern = trimPattern(parsePattern(root));
         Map<String, Ingredient> key = parseKey(root);
         ItemStack result = parseResult(root);
 
@@ -115,6 +115,62 @@ public final class RecipeConfigLoader {
             out[i] = arr.get(i).getAsString();
         }
         return out;
+    }
+
+    /**
+     * Trims fully-empty rows/columns around the pattern so recipes behave like vanilla shaped recipes.
+     * Example:
+     *  ["   ", " C ", "   "] -> ["C"]
+     *  [" C "] -> ["C"]
+     */
+    private static String[] trimPattern(String[] pattern) {
+        if (pattern.length == 0) return pattern;
+
+        int height = pattern.length;
+        int width = pattern[0].length();
+        for (String row : pattern) {
+            if (row.length() != width) {
+                throw new JsonSyntaxException("All pattern rows must have the same length");
+            }
+        }
+
+        int top = 0;
+        int bottom = height - 1;
+        int left = 0;
+        int right = width - 1;
+
+        // trim empty rows from top
+        while (top <= bottom && isRowEmpty(pattern[top])) top++;
+        // trim empty rows from bottom
+        while (bottom >= top && isRowEmpty(pattern[bottom])) bottom--;
+
+        // trim empty columns from left/right
+        while (left <= right && isColEmpty(pattern, top, bottom, left)) left++;
+        while (right >= left && isColEmpty(pattern, top, bottom, right)) right--;
+
+        if (top > bottom || left > right) {
+            throw new JsonSyntaxException("Pattern cannot be entirely empty");
+        }
+
+        String[] out = new String[(bottom - top) + 1];
+        for (int y = top; y <= bottom; y++) {
+            out[y - top] = pattern[y].substring(left, right + 1);
+        }
+        return out;
+    }
+
+    private static boolean isRowEmpty(String row) {
+        for (int i = 0; i < row.length(); i++) {
+            if (row.charAt(i) != ' ') return false;
+        }
+        return true;
+    }
+
+    private static boolean isColEmpty(String[] pattern, int top, int bottom, int col) {
+        for (int y = top; y <= bottom; y++) {
+            if (pattern[y].charAt(col) != ' ') return false;
+        }
+        return true;
     }
 
     private static Map<String, Ingredient> parseKey(JsonObject root) {

--- a/src/main/java/com/junnio/polym/config/RecipeConfigLoader.java
+++ b/src/main/java/com/junnio/polym/config/RecipeConfigLoader.java
@@ -1,0 +1,168 @@
+package com.junnio.polym.config;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import com.junnio.polym.Polym;
+import com.junnio.polym.recipe.PolymRecipe;
+import com.junnio.polym.recipe.PolymRecipeRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.registry.Registries;
+import net.minecraft.util.Identifier;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Loads Polym Table-only recipes from config/polym/recipes/*.json.
+ */
+public final class RecipeConfigLoader {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final Path CONFIG_DIR = Paths.get("config", Polym.MOD_ID, "recipes");
+
+    private RecipeConfigLoader() {}
+
+    /**
+     * Creates an example JSON file on first run to show players the expected format.
+     */
+    public static void createExampleRecipeIfMissing() {
+        try {
+            Files.createDirectories(CONFIG_DIR);
+
+            Path example = CONFIG_DIR.resolve("example_copper_coin.json");
+            if (Files.exists(example)) return;
+
+            JsonObject root = new JsonObject();
+            root.addProperty("id", "example_copper_coin");
+
+            JsonArray pattern = new JsonArray();
+            pattern.add("   ");
+            pattern.add(" C ");
+            pattern.add("   ");
+            root.add("pattern", pattern);
+
+            JsonObject key = new JsonObject();
+            key.addProperty("C", "minecraft:copper_ingot");
+            root.add("key", key);
+
+            JsonObject result = new JsonObject();
+            result.addProperty("item", Polym.MOD_ID + ":copper_coin");
+            result.addProperty("count", 1);
+            root.add("result", result);
+
+            Files.writeString(example, GSON.toJson(root));
+            Polym.LOGGER.info("Created example Polym recipe config: {}", example.toAbsolutePath());
+        } catch (IOException e) {
+            Polym.LOGGER.error("Failed to create example Polym recipe config: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Reloads all recipes from disk into PolymRecipeRegistry.
+     */
+    public static void loadAllRecipes() {
+        PolymRecipeRegistry.clear();
+
+        int loaded = 0;
+        try {
+            Files.createDirectories(CONFIG_DIR);
+
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(CONFIG_DIR, "*.json")) {
+                for (Path p : stream) {
+                    try {
+                        loadRecipeFile(p);
+                        loaded++;
+                    } catch (Exception ex) {
+                        Polym.LOGGER.error("Failed to load recipe config {}: {}", p.getFileName(), ex.getMessage());
+                    }
+                }
+            }
+        } catch (IOException e) {
+            Polym.LOGGER.error("Failed to read recipe config directory {}: {}", CONFIG_DIR.toAbsolutePath(), e.getMessage());
+        }
+
+        Polym.LOGGER.info("Loaded {} Polym Table config recipes", loaded);
+    }
+
+    private static void loadRecipeFile(Path path) throws IOException {
+        JsonObject root = JsonParser.parseString(Files.readString(path)).getAsJsonObject();
+
+        String id = requireString(root, "id");
+        String[] pattern = parsePattern(root);
+        Map<String, Ingredient> key = parseKey(root);
+        ItemStack result = parseResult(root);
+
+        PolymRecipe recipe = new PolymRecipe(pattern, key, result);
+        PolymRecipeRegistry.register(id, recipe);
+    }
+
+    private static String[] parsePattern(JsonObject root) {
+        if (!root.has("pattern") || !root.get("pattern").isJsonArray()) {
+            throw new JsonSyntaxException("Missing or invalid 'pattern' array");
+        }
+        JsonArray arr = root.getAsJsonArray("pattern");
+        String[] out = new String[arr.size()];
+        for (int i = 0; i < arr.size(); i++) {
+            out[i] = arr.get(i).getAsString();
+        }
+        return out;
+    }
+
+    private static Map<String, Ingredient> parseKey(JsonObject root) {
+        if (!root.has("key") || !root.get("key").isJsonObject()) {
+            throw new JsonSyntaxException("Missing or invalid 'key' object");
+        }
+
+        JsonObject obj = root.getAsJsonObject("key");
+        Map<String, Ingredient> map = new HashMap<>();
+
+        for (String symbol : obj.keySet()) {
+            if (symbol.length() != 1) {
+                throw new JsonSyntaxException("Key symbol must be a single character, got: " + symbol);
+            }
+
+            String itemId = obj.get(symbol).getAsString();
+            Identifier id = Identifier.of(itemId);
+            if (!Registries.ITEM.containsId(id)) {
+                throw new JsonSyntaxException("Unknown item in key: " + itemId);
+            }
+
+            map.put(symbol, Ingredient.ofItems(Registries.ITEM.get(id)));
+        }
+
+        return map;
+    }
+
+    private static ItemStack parseResult(JsonObject root) {
+        if (!root.has("result") || !root.get("result").isJsonObject()) {
+            throw new JsonSyntaxException("Missing or invalid 'result' object");
+        }
+
+        JsonObject obj = root.getAsJsonObject("result");
+        String itemId = requireString(obj, "item");
+        int count = obj.has("count") ? obj.get("count").getAsInt() : 1;
+
+        Identifier id = Identifier.of(itemId);
+        if (!Registries.ITEM.containsId(id)) {
+            throw new JsonSyntaxException("Unknown result item: " + itemId);
+        }
+
+        return new ItemStack(Registries.ITEM.get(id), Math.max(1, count));
+    }
+
+    private static String requireString(JsonObject obj, String field) {
+        if (!obj.has(field)) {
+            throw new JsonSyntaxException("Missing required field: " + field);
+        }
+        return obj.get(field).getAsString();
+    }
+}

--- a/src/main/java/com/junnio/polym/recipe/PolymRecipeRegistry.java
+++ b/src/main/java/com/junnio/polym/recipe/PolymRecipeRegistry.java
@@ -1,0 +1,40 @@
+package com.junnio.polym.recipe;
+
+import com.junnio.polym.Polym;
+import net.minecraft.recipe.input.CraftingRecipeInput;
+import net.minecraft.world.World;
+
+import java.util.*;
+
+/**
+ * In-memory registry for Polym Table recipes loaded from config files.
+ * These recipes are used only by the Polym Table and are NOT registered in Minecraft's RecipeManager.
+ */
+public final class PolymRecipeRegistry {
+    private static final Map<String, PolymRecipe> RECIPES = new LinkedHashMap<>();
+
+    private PolymRecipeRegistry() {}
+
+    public static void register(String id, PolymRecipe recipe) {
+        RECIPES.put(id, recipe);
+        Polym.LOGGER.info("Registered Polym config recipe: {}", id);
+    }
+
+    public static Optional<PolymRecipe> getFirstMatch(CraftingRecipeInput input, World world) {
+        return RECIPES.values().stream()
+                .filter(r -> r.matches(input, world))
+                .findFirst();
+    }
+
+    public static void clear() {
+        RECIPES.clear();
+    }
+
+    public static int size() {
+        return RECIPES.size();
+    }
+
+    public static Collection<PolymRecipe> all() {
+        return Collections.unmodifiableCollection(RECIPES.values());
+    }
+}

--- a/src/main/java/com/junnio/polym/screen/PolymTableScreenHandler.java
+++ b/src/main/java/com/junnio/polym/screen/PolymTableScreenHandler.java
@@ -21,7 +21,7 @@ public class PolymTableScreenHandler extends ScreenHandler {
     private final CraftingInventory craftingInventory;
     private final Inventory resultInventory;
 
-    public PolymTableScreenHandler(int syncId, PlayerInventory playerInventory) {
+    public PolymTableScreenHandler(int syncId, PlayerInventory playerInventory, PlayerEntity player) {
         super(ModScreenHandlers.POLYM_TABLE_SCREEN_HANDLER, syncId);
 
         this.world = playerInventory.player.getEntityWorld();
@@ -156,9 +156,10 @@ public class PolymTableScreenHandler extends ScreenHandler {
     public void updateRecipeOutput() {
         if (!this.world.isClient()) {
             CraftingRecipeInput recipeInput = craftingInventory.createRecipeInput();
-
+            System.out.print("test1");
             Optional<PolymRecipe> recipe = PolymRecipeRegistry.getFirstMatch(recipeInput, this.world);
             if (recipe.isPresent()) {
+                System.out.print("test2");
                 ItemStack result = recipe.get().craft(recipeInput, this.world.getRegistryManager());
                 this.resultInventory.setStack(0, result);
                 return;

--- a/src/main/java/com/junnio/polym/screen/PolymTableScreenHandler.java
+++ b/src/main/java/com/junnio/polym/screen/PolymTableScreenHandler.java
@@ -1,7 +1,7 @@
 package com.junnio.polym.screen;
 
-import com.junnio.polym.recipe.ModRecipes;
 import com.junnio.polym.recipe.PolymRecipe;
+import com.junnio.polym.recipe.PolymRecipeRegistry;
 import com.junnio.polym.sound.ModSounds;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
@@ -9,28 +9,22 @@ import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.inventory.CraftingResultInventory;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
-import net.minecraft.recipe.CraftingRecipe;
-import net.minecraft.recipe.RecipeEntry;
-import net.minecraft.recipe.RecipeType;
 import net.minecraft.recipe.input.CraftingRecipeInput;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.Slot;
-import net.minecraft.util.Identifier;
 import net.minecraft.world.World;
 
-import java.util.Objects;
 import java.util.Optional;
 
 public class PolymTableScreenHandler extends ScreenHandler {
     private final World world;
     private final CraftingInventory craftingInventory;
     private final Inventory resultInventory;
-    private final PlayerEntity playerentity;
-    public PolymTableScreenHandler(int syncId, PlayerInventory playerInventory, PlayerEntity playerentity) {
+
+    public PolymTableScreenHandler(int syncId, PlayerInventory playerInventory) {
         super(ModScreenHandlers.POLYM_TABLE_SCREEN_HANDLER, syncId);
 
         this.world = playerInventory.player.getEntityWorld();
-        this.playerentity = playerentity;
 
         this.resultInventory = new CraftingResultInventory();
 
@@ -69,6 +63,7 @@ public class PolymTableScreenHandler extends ScreenHandler {
         }
 
     }
+
     private void consumeIngredients() {
         for (int i = 0; i < craftingInventory.size(); i++) {
             ItemStack slotStack = craftingInventory.getStack(i);
@@ -161,39 +156,14 @@ public class PolymTableScreenHandler extends ScreenHandler {
     public void updateRecipeOutput() {
         if (!this.world.isClient()) {
             CraftingRecipeInput recipeInput = craftingInventory.createRecipeInput();
-            Optional<RecipeEntry<PolymRecipe>> polymRecipe = this.world.getServer()
-                    .getRecipeManager()
-                    .getFirstMatch(ModRecipes.POLYM_CRAFTING_TYPE, recipeInput, this.world);
 
-            if (polymRecipe.isPresent()) {
-                ItemStack result = polymRecipe.get().value().craft(recipeInput, this.world.getRegistryManager());
+            Optional<PolymRecipe> recipe = PolymRecipeRegistry.getFirstMatch(recipeInput, this.world);
+            if (recipe.isPresent()) {
+                ItemStack result = recipe.get().craft(recipeInput, this.world.getRegistryManager());
                 this.resultInventory.setStack(0, result);
                 return;
             }
 
-            Optional<RecipeEntry<CraftingRecipe>> vanillaRecipe = this.world.getServer()
-                    .getRecipeManager()
-                    .getFirstMatch(RecipeType.CRAFTING, recipeInput, this.world);
-
-            if (vanillaRecipe.isPresent()) {
-
-                // 3. Special guild recipes check
-                if (playerentity.getCommandTags().contains("Guild") &&
-                        vanillaRecipe.get().id().getValue().getNamespace().equals("polym") &&
-                        vanillaRecipe.get().id().getValue().getPath().startsWith("guild_")) {
-                    ItemStack result = vanillaRecipe.get().value().craft(recipeInput, this.world.getRegistryManager());
-                    this.resultInventory.setStack(0, result);
-                    return;
-                }
-
-                // 4. Regular polymorph vanilla recipes (non-guild)
-                if (vanillaRecipe.get().id().getValue().getNamespace().equals("polym") &&
-                        !vanillaRecipe.get().id().getValue().getPath().startsWith("guild_")) {
-                    ItemStack result = vanillaRecipe.get().value().craft(recipeInput, this.world.getRegistryManager());
-                    this.resultInventory.setStack(0, result);
-                    return;
-                }
-            }
             this.resultInventory.setStack(0, ItemStack.EMPTY);
         }
     }


### PR DESCRIPTION
Adds config-driven, Polym-Table-only recipes.

### What changed
- Added `RecipeConfigLoader` to load recipes from `config/polym/recipes/*.json`.
- Added `PolymRecipeRegistry` in-memory store (not registered in `RecipeManager`).
- Updated `PolymTableScreenHandler` to use config recipes only.
- Updated `Polym` init to create an example recipe and load recipes at startup.

### Usage
1. Run once to generate `config/polym/recipes/example_copper_coin.json`.
2. Add more `*.json` recipe files to that folder.

### Notes
- These recipes are NOT datapack recipes and won’t appear in the vanilla recipe book.
